### PR TITLE
feat: Implement book series functionality

### DIFF
--- a/models.py
+++ b/models.py
@@ -340,6 +340,26 @@ class BookManager:
             return []
         return sorted(list(set(book.author for book in self._cache.values() if book.author)))
 
+    def get_all_series_names(self) -> List[str]:
+        """Gets a list of unique and sorted series names."""
+        self._ensure_cache()
+        if not self._cache:
+            return []
+        
+        series_names = set()
+        for book in self._cache.values():
+            if book.series and book.series.strip():
+                series_names.add(book.series)
+        return sorted(list(series_names))
+
+    def get_books_by_series(self, series_name: str) -> List[Book]:
+        """Gets a list of books belonging to a specific series."""
+        self._ensure_cache()
+        if not self._cache:
+            return []
+        
+        return [book for book in self._cache.values() if book.series == series_name]
+
     def search_books_by_text(self, text: str) -> List[Book]:
         """Searches books by text in title or author."""
         if not text:

--- a/screens/main.py
+++ b/screens/main.py
@@ -3,6 +3,7 @@ import os # Added for os.listdir
 from pathlib import Path
 from functools import partial # For passing arguments to callbacks
 
+from typing import Optional, List # Added Optional, List
 from textual.app import ComposeResult
 from textual.screen import Screen
 from textual.containers import Container # Removed Horizontal, Vertical as they are not directly used here
@@ -20,6 +21,7 @@ from screens.edit import EditScreen
 from screens.settings import SettingsScreen
 from screens.inputscreen import InputScreen
 from screens.confirmationscreen import ConfirmationScreen
+from screens.serieslist import SeriesListScreen # Import SeriesListScreen
 
 
 class MainScreen(Screen):
@@ -32,13 +34,16 @@ class MainScreen(Screen):
         ("ctrl+r", "reverse_sort", "Sort Order"), # Toggle sort order for the current field
         ("ctrl+o", "open_book", "Open"),
         ("ctrl+s", "settings", "Settings"),
-        ("ctrl+e", "delete_book_action", "Delete Book")
+        ("ctrl+e", "delete_book_action", "Delete Book"),
+        ("ctrl+p", "filter_by_series", "Filter Series"),
+        ("alt+s", "show_series_list", "Series List")
     ]
 
     def __init__(self, config_manager: ConfigManager, library_manager: LibraryManager):
         super().__init__()
         self.config_manager = config_manager
         self.library_manager = library_manager
+        self.current_series_filter: Optional[str] = None
         self.main_upload_dir = config_manager.paths["upload_dir_path"]
         self.logger = AppLogger.get_logger()
 
@@ -64,8 +69,60 @@ class MainScreen(Screen):
 
     def reload_table_data(self) -> None:
         """Reloads and sorts books, then updates the table display."""
-        books = self.library_manager.books.sort_books(self.sort_field, reverse=self.sort_reverse)
+        books: List[Book] 
+        if self.current_series_filter:
+            books = self.library_manager.books.get_books_by_series(self.current_series_filter)
+            # Sort the filtered books
+            if books: # Ensure books list is not empty before trying to access books[0] or sorting
+                # Determine sort key
+                if self.sort_field == 'tags':
+                    sort_key = lambda b: (", ".join(b.tags) if b.tags else "").lower()
+                elif hasattr(books[0], self.sort_field):
+                    sort_key = lambda b: (val.lower() if isinstance(val := getattr(b, self.sort_field), str) 
+                                          else val if val is not None else "")
+                else: # Fallback if sort_field is somehow invalid for the book object
+                    sort_key = lambda b: ""
+                
+                books.sort(key=sort_key, reverse=self.sort_reverse)
+        else:
+            books = self.library_manager.books.sort_books(self.sort_field, reverse=self.sort_reverse)
         self._display_books_in_table(books)
+
+    def action_filter_by_series(self) -> None:
+        """Handles the 'filter_by_series' action: opens an input dialog for series name."""
+        series_names = self.library_manager.books.get_all_series_names()
+        if not series_names:
+            self.notify("No series available to filter by.", title="Filter Series")
+            return
+
+        def handle_series_input(series_name_input: str) -> None:
+            """Callback for the series input dialog."""
+            series_name = series_name_input.strip()
+            if not series_name:
+                self.current_series_filter = None
+                self.reload_table_data()
+                self.notify("Series filter cleared. Displaying all books.", title="Filter Cleared")
+                return
+
+            if series_name not in series_names:
+                self.notify(f"Series '{series_name}' not found. Displaying all books.", title="Filter Series", severity="warning")
+                self.current_series_filter = None
+                self.reload_table_data()
+                return
+            
+            self.current_series_filter = series_name
+            self.reload_table_data()
+            self.notify(f"Showing books in series: '{series_name}'. Press F5 or Ctrl+P (empty) to reset.", title="Filter Active")
+
+        self.notify(f"Available series: {', '.join(series_names)}", title="Available Series", timeout=8)
+        self.app.push_screen(
+            InputScreen(
+                title="Filter by Series",
+                placeholder="Enter series name (or empty to clear)",
+                prompt="Type series name to filter. F5 also clears.",
+                callback=handle_series_input
+            )
+        )
 
     def action_edit_book(self) -> None:
         """Handles the 'edit_book' action: opens the EditScreen for the selected book."""
@@ -283,7 +340,8 @@ class MainScreen(Screen):
     def action_reverse_sort(self) -> None:
         """Handles the 'reverse_sort' action: changes sort field or reverses current sort order."""
         table = self.query_one("#books-table", DataTableBook)
-        column_mapping = { 0: "added", 1: "author", 2: "title", 3: "read", 4: "tags" }
+        # Updated column mapping for the new "Series" column
+        column_mapping = { 0: "added", 1: "author", 2: "title", 3: "series", 4: "read", 5: "tags" }
         current_cursor_column = table.cursor_column
         new_sort_field = self.sort_field
         if current_cursor_column is not None and current_cursor_column in column_mapping:
@@ -321,5 +379,10 @@ class MainScreen(Screen):
 
     def action_reset_search(self) -> None:
         """Handles the 'reset_search' action: clears search and reloads all books."""
+        self.current_series_filter = None
         self.reload_table_data()
-        self.notify("Search reset. Displaying all books.", title="Search Reset")
+        self.notify("All filters reset. Displaying all books.", title="Filters Reset")
+
+    def action_show_series_list(self) -> None:
+        """Handles the 'show_series_list' action: opens the SeriesListScreen."""
+        self.app.push_screen(SeriesListScreen(self.library_manager))

--- a/screens/seriesbooklist.py
+++ b/screens/seriesbooklist.py
@@ -1,0 +1,87 @@
+from typing import List
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.containers import Container
+from textual.widgets import Header, Footer, Label
+from models import Book, LibraryManager
+from widgets.datatablebook import DataTableBook
+from tools.logger import AppLogger # Assuming AppLogger is the standard logger
+
+class SeriesBooksScreen(Screen):
+    """A screen to display books belonging to a specific series."""
+    
+    BINDINGS = [("escape", "back", "Back")]
+
+    def __init__(self, library_manager: LibraryManager, series_name: str, books: List[Book]):
+        super().__init__()
+        self.library_manager = library_manager
+        self.series_name = series_name
+        self.books = books
+        self.logger = AppLogger.get_logger()
+        self.logger.info(f"SeriesBooksScreen initialized for series: {self.series_name} with {len(self.books)} books.")
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Label(f"Books in Series: {self.series_name}", classes="title")
+        yield Container(DataTableBook(id="series-books-table"), id="series-books-container")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Called when the screen is mounted. Populates the table."""
+        try:
+            table = self.query_one("#series-books-table", DataTableBook)
+            table.update_table(self.books)
+            self.logger.info(f"DataTableBook populated with {len(self.books)} books for series '{self.series_name}'.")
+        except Exception as e:
+            self.logger.error(f"Error populating DataTableBook in SeriesBooksScreen: {e}", exc_info=True)
+            self.notify(f"Error loading books for series: {e}", severity="error", title="Load Error")
+
+
+    def action_back(self) -> None:
+        """Handles the 'back' action: pops the current screen."""
+        self.app.pop_screen()
+        self.logger.info("Popped SeriesBooksScreen.")
+
+# Optional: action_open_book could be added here later if needed.
+# from filesystem import FileSystemHandler
+# from formvalidators import FormValidators
+# from pathlib import Path
+#
+#    def action_open_book(self) -> None:
+#        """Handles the 'open_book' action: opens the selected book file."""
+#        try:
+#            table = self.query_one("#series-books-table", DataTableBook)
+#            book_uuid = table.current_uuid
+#            if not book_uuid:
+#                self.logger.warning("Attempt to open book without selection from SeriesBooksScreen.")
+#                self.notify("No book selected.", severity="warning", title="Selection Missing")
+#                return
+#
+#            book = self.library_manager.books.get_book(book_uuid)
+#            if not book:
+#                self.logger.error(f"Book with UUID {book_uuid} not found for opening from SeriesBooksScreen.")
+#                self.notify(f"Book not found.", severity="error", title="Error")
+#                return
+#
+#            is_valid, fs_name_or_error = FormValidators.validate_author_name(book.author)
+#            if not is_valid:
+#                self.notify(f"Invalid author name for path: {fs_name_or_error}", severity="error", title="Path Error")
+#                return
+#
+#            book_path_str = self.library_manager.books.get_book_path(book)
+#            if not Path(book_path_str).exists():
+#                self.notify(f"File not found: {book_path_str}", severity="error", title="File Error")
+#                return
+#            FileSystemHandler.open_file_with_default_app(book_path_str)
+#
+#        except ValueError as e:
+#            self.logger.error(f"Error preparing to open book from SeriesBooksScreen: {e}", exc_info=True)
+#            self.notify(f"Error: {str(e)}", severity="error", title="Open Error")
+#        except RuntimeError as e:
+#            self.logger.error(f"Error opening book file from SeriesBooksScreen: {e}", exc_info=True)
+#            self.notify(f"Could not open file: {str(e)}", severity="error", title="Open Error")
+#        except Exception as e:
+#            self.logger.error("Unexpected error during open book action from SeriesBooksScreen.", exc_info=e)
+#            self.notify(f"An unexpected error occurred: {str(e)}", severity="error", title="Error")
+
+# Ensure BINDINGS would include ("ctrl+o", "open_book", "Open Book") if action_open_book is enabled.

--- a/screens/serieslist.py
+++ b/screens/serieslist.py
@@ -1,0 +1,77 @@
+from typing import List
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widgets import Header, Footer, DataTable, Label
+from textual.containers import Container
+from textual import on
+from models import LibraryManager # To access BookManager
+from tools.logger import AppLogger # Assuming AppLogger is the standard logger
+
+# Import SeriesBooksScreen from .seriesbooklist
+from .seriesbooklist import SeriesBooksScreen
+
+class SeriesListScreen(Screen):
+    """A screen to display a list of all book series."""
+
+    BINDINGS = [("escape", "back", "Back")]
+
+    def __init__(self, library_manager: LibraryManager):
+        super().__init__()
+        self.library_manager = library_manager
+        self.logger = AppLogger.get_logger()
+        self.series_names: List[str] = []
+        self.logger.info("SeriesListScreen initialized.")
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Label("Book Series", classes="title")
+        yield Container(DataTable(id="series-list-table", cursor_type="row"), id="series-list-container")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        """Called when the screen is mounted. Fetches and displays series names."""
+        try:
+            self.series_names = self.library_manager.books.get_all_series_names()
+            table = self.query_one("#series-list-table", DataTable)
+            table.add_column("Series Name", key="series_name")
+
+            if self.series_names:
+                for name in self.series_names:
+                    table.add_row(name, key=name) # Use series name as key
+                self.logger.info(f"Displayed {len(self.series_names)} series names.")
+            else:
+                self.logger.info("No series found in the library.")
+                self.notify("No series found in the library.")
+                # Optional: Display a message in the table or container.
+                # For example, by adding a row with a message or updating a Label.
+        except Exception as e:
+            self.logger.error(f"Error mounting SeriesListScreen: {e}", exc_info=True)
+            self.notify(f"Error loading series list: {e}", severity="error", title="Load Error")
+
+
+    @on(DataTable.RowSelected, "#series-list-table")
+    def on_series_selected(self, event: DataTable.RowSelected) -> None:
+        """Handles the selection of a series from the table."""
+        try:
+            # event.row_key.value should give the series name because we set key=name in add_row
+            selected_series_name = event.row_key.value 
+            if selected_series_name:
+                self.logger.info(f"Series selected: {selected_series_name}")
+                books_in_series = self.library_manager.books.get_books_by_series(selected_series_name)
+                if books_in_series:
+                    self.logger.info(f"Found {len(books_in_series)} books for series '{selected_series_name}'. Pushing SeriesBooksScreen.")
+                    self.app.push_screen(SeriesBooksScreen(self.library_manager, selected_series_name, books_in_series))
+                else:
+                    self.logger.info(f"No books found for series '{selected_series_name}', though series name exists. Not navigating.")
+                    self.notify(f"No books found in series '{selected_series_name}'.") # User feedback
+            else:
+                self.logger.warning("Series selection event triggered with no selected_series_name.")
+        except Exception as e:
+            self.logger.error(f"Error handling series selection: {e}", exc_info=True)
+            self.notify(f"Error processing series selection: {e}", severity="error", title="Selection Error")
+
+
+    def action_back(self) -> None:
+        """Handles the 'back' action: pops the current screen."""
+        self.app.pop_screen()
+        self.logger.info("Popped SeriesListScreen.")

--- a/widgets/datatablebook.py
+++ b/widgets/datatablebook.py
@@ -9,6 +9,7 @@ class DataTableBook(DataTable):
         self.add_column("Added", width=10)      # Column for "Aggiunto"
         self.add_column("Author", width=25)     # Column for "Autore"
         self.add_column("Title", width=90)      # Column for "Titolo"
+        self.add_column("Series", width=30)     # Column for "Series"
         self.add_column("Read", width=5)        # Column for "Letto"
         self.add_column("Tags", width=30)
         self.cursor_type = "row"
@@ -29,10 +30,21 @@ class DataTableBook(DataTable):
             added_date = b.added.strftime("%Y-%m-%d") # Format added date
             tags_display = ", ".join(b.tags) # Join tags into a comma-separated string
 
+            series_display = "—"
+            if b.series:
+                if b.num_series is not None:
+                    if isinstance(b.num_series, float) and b.num_series.is_integer():
+                        series_display = f"{b.series} [{int(b.num_series)}]"
+                    else:
+                        series_display = f"{b.series} [{b.num_series}]"
+                else:
+                    series_display = b.series
+            
             self.add_row(
                 added_date,
                 b.author,
                 b.title,
+                series_display,
                 read_date,
                 tags_display,
                 key=b.uuid # Use book's UUID as the row key


### PR DESCRIPTION
This commit introduces a comprehensive book series feature, allowing you to manage and browse books grouped by series.

Key changes include:

1.  Data Model:
    *   Leveraged existing `series` and `num_series` attributes in the `Book` model.
    *   `BookManager` in `models.py` enhanced with:
        *   `get_all_series_names()`: To retrieve a list of all unique series.
        *   `get_books_by_series(series_name)`: To fetch books belonging to a specific series.

2.  Book Management:
    *   `widgets/bookform.py`, `screens/add.py`, and `screens/edit.py` were verified to correctly handle input and storage of series information for books.

3.  Main Screen (`screens/main.py`):
    *   Display: `widgets/datatablebook.py` updated to include a "Series" column, displaying series and number (e.g., "Series Name [1]").
    *   Filtering:
        *   Added `Ctrl+P` binding to filter books by series.
        *   You will be prompted to enter a series name.
        *   The table updates to show only books from the selected series.
        *   `F5` or clearing the series filter input resets the view.
    *   Sorting: Column mapping for sorting updated to include the new "Series" column.

4.  New Screens for Series Navigation:
    *   Series List Screen (`screens/serieslist.py`):
        *   Accessible via `Alt+S` from the main screen.
        *   Displays a list of all available series.
    *   Series Books Screen (`screens/seriesbooklist.py`):
        *   Opened by selecting a series from the `SeriesListScreen`.
        *   Displays all books belonging to the selected series using the `DataTableBook` widget.

This feature enhances book organization and provides you with new ways to discover and manage your library content based on series.